### PR TITLE
Update README.es.md fixed broken asset image #hacktoberfest

### DIFF
--- a/translations/README.es.md
+++ b/translations/README.es.md
@@ -65,7 +65,7 @@ git checkout -b add-alonzo-church
 
 Abre el archivo `Contributors.md` en un editor de texto y añade tu nombre. No lo añadas ni al principio ni al final del archivo, hazlo en cualquier otro sitio. Guarda el archivo.
 
-<img align="right" width="450" src="assets/git-status.png" alt="git status" />
+<img align="right" width="450" src="../assets/git-status.png" alt="git status" />
 
 Si vas al directorio del proyecto y ejecutas el comando  `git status`, verás que hay cambios. 
 


### PR DESCRIPTION
The assed image for git status had an incorrect path and was being displayed broken in the Spanish README translation. #hacktoberfest 